### PR TITLE
feat(teachers): add teacher slices

### DIFF
--- a/backend/api/src/EduGraph.Core/EduGraph.Core.csproj
+++ b/backend/api/src/EduGraph.Core/EduGraph.Core.csproj
@@ -39,6 +39,7 @@
 
     <ItemGroup>
       <Folder Include="Features\Students\" />
+      <Folder Include="Features\Teachers\" />
       <Folder Include="wwwroot\" />
     </ItemGroup>
 

--- a/backend/api/src/EduGraph.Core/Features/Teachers/Create.cs
+++ b/backend/api/src/EduGraph.Core/Features/Teachers/Create.cs
@@ -1,0 +1,150 @@
+using System.Net;
+using EduGraph.Core.Extensions;
+using EduGraph.Core.Features.Common.Auth;
+using EduGraph.Core.Features.Common.Endpoints;
+using EduGraph.Core.Features.Common.ValidationRules;
+using EduGraph.Domain.Enums;
+using EduGraph.Infrastructure.SQLite;
+using EduGraph.Infrastructure.SQLite.Entities;
+using EduGraph.Infrastructure.SQLite.Extensions;
+using EduGraph.SharedKernel.Interfaces;
+using EduGraph.SharedKernel.Models;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace EduGraph.Core.Features.Teachers;
+
+internal static class Create
+{
+    internal sealed record Request(
+        string FullName,
+        string Login,
+        string Password,
+        string ConfirmPassword
+    );
+
+    internal sealed class Validator : AbstractValidator<Request>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.FullName)
+                .NotEmpty();
+            RuleFor(x => x.Login)
+                .NotEmpty()
+                .MinimumLength(RequestValidationRules.LoginMinLength);
+            RuleFor(x => x.Password)
+                .NotEmpty()
+                .MinimumLength(RequestValidationRules.PasswordMinLength);
+            RuleFor(x => x.ConfirmPassword)
+                .Equal(x => x.Password)
+                .WithMessage("Паролі не збігаються");
+        }
+    }
+
+    internal sealed class Endpoint : IEndpoint
+    {
+        public void MapEndpoint(IEndpointRouteBuilder app)
+        {
+            app.MapPost("teachers", Handle)
+                .RequireAuthorization(AuthorizationPolicies.Admin)
+                .WithTags("Teachers")
+                .WithRequestValidation<Request>()
+                .Produces<int>(StatusCodes.Status201Created)
+                .ProducesProblem(StatusCodes.Status400BadRequest)
+                .ProducesProblem(StatusCodes.Status409Conflict)
+                .ProducesProblem(StatusCodes.Status500InternalServerError);
+        }
+
+        private static async Task<IResult> Handle(
+            [FromBody] Request request,
+            [FromServices] IValidator<Request> validator,
+            [FromServices] Handler handler,
+            CancellationToken cancellationToken)
+        {
+            ValidationResult validateCreateTeacherRequest = await validator.ValidateAsync(request, cancellationToken);
+
+            if (!validateCreateTeacherRequest.IsValid)
+            {
+                return Results.ValidationProblem(validateCreateTeacherRequest.ToDictionary());
+            }
+
+            Result<int> createTeacherResult = await handler.HandleAsync(request, cancellationToken);
+
+            if (createTeacherResult.IsFailure)
+            {
+                return createTeacherResult.ToHttpFailure();
+            }
+
+            return TypedResults.Created($"teachers/{createTeacherResult.Value}", createTeacherResult.Value);
+        }
+    }
+
+    internal sealed class Handler(
+        UserManager<User> userManager,
+        EduGraphContext db,
+        IPasswordHasher<User> passwordHasher) : IScopedType
+    {
+        public async Task<Result<int>> HandleAsync(Request request, CancellationToken cancellationToken)
+        {
+            User? existingUser = await userManager.FindByNameAsync(request.Login);
+
+            if (existingUser is not null)
+            {
+                return new ErrorDetails(
+                    "Цей логін вже зайнятий",
+                    HttpStatusCode.Conflict
+                );
+            }
+
+            string passwordHash = passwordHasher.HashPassword(null!, request.Password);
+
+            Result<User> createUserResult = User.Create(
+                request.Login,
+                request.FullName,
+                UserType.Teacher,
+                passwordHash
+            );
+
+            if (createUserResult.IsFailure)
+            {
+                return createUserResult.ErrorDetails!;
+            }
+
+            User user = createUserResult.Value!;
+
+            await using IDbContextTransaction transaction = await db.Database.BeginTransactionAsync(cancellationToken);
+
+            IdentityResult createIdentityUserResult = await userManager.CreateAsync(user);
+
+            if (createIdentityUserResult.Succeeded is false)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+
+                return new ErrorDetails(
+                    createIdentityUserResult.GetErrorMessage(),
+                    HttpStatusCode.InternalServerError
+                );
+            }
+
+            IdentityResult addUserToRoleResult = await userManager.AddToRoleAsync(user, nameof(UserType.Teacher));
+
+            if (addUserToRoleResult.Succeeded is false)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+
+                return new ErrorDetails(
+                    addUserToRoleResult.GetErrorMessage(),
+                    HttpStatusCode.InternalServerError
+                );
+            }
+
+            await db.SaveChangesAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+
+            return user.Id;
+        }
+    }
+}

--- a/backend/api/src/EduGraph.Core/Features/Teachers/Delete.cs
+++ b/backend/api/src/EduGraph.Core/Features/Teachers/Delete.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using EduGraph.Core.Extensions;
+using EduGraph.Core.Features.Common.Auth;
+using EduGraph.Core.Features.Common.Endpoints;
+using EduGraph.Domain.Enums;
+using EduGraph.Infrastructure.SQLite.Entities;
+using EduGraph.Infrastructure.SQLite.Extensions;
+using EduGraph.SharedKernel.Interfaces;
+using EduGraph.SharedKernel.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EduGraph.Core.Features.Teachers;
+
+internal static class Delete
+{
+    internal sealed class Endpoint : IEndpoint
+    {
+        public void MapEndpoint(IEndpointRouteBuilder app)
+        {
+            app.MapDelete("teachers/{id:int}", Handle)
+                .RequireAuthorization(AuthorizationPolicies.Admin)
+                .WithTags("Teachers")
+                .Produces(StatusCodes.Status204NoContent)
+                .ProducesProblem(StatusCodes.Status404NotFound)
+                .ProducesProblem(StatusCodes.Status500InternalServerError);
+        }
+
+        private static async Task<IResult> Handle(
+            [FromRoute] int id,
+            [FromServices] Handler handler,
+            CancellationToken cancellationToken)
+        {
+            Result deleteTeacherResult = await handler.HandleAsync(id, cancellationToken);
+
+            if (deleteTeacherResult.IsFailure)
+            {
+                return deleteTeacherResult.ToHttpFailure();
+            }
+
+            return TypedResults.NoContent();
+        }
+    }
+
+    internal sealed class Handler(UserManager<User> userManager) : IScopedType
+    {
+        public async Task<Result> HandleAsync(int id, CancellationToken cancellationToken)
+        {
+#pragma warning disable CA1305
+            User? user = await userManager.FindByIdAsync(id.ToString());
+#pragma warning restore CA1305
+
+            if (user is null)
+            {
+                return new ErrorDetails(
+                    "Викладача не знайдено",
+                    HttpStatusCode.NotFound
+                );
+            }
+
+            if (user.Type != UserType.Teacher)
+            {
+                return new ErrorDetails(
+                    "Викладача не знайдено",
+                    HttpStatusCode.NotFound
+                );
+            }
+
+            IdentityResult deleteTeacherResult = await userManager.DeleteAsync(user);
+
+            if (deleteTeacherResult.Succeeded is false)
+            {
+                return new ErrorDetails(
+                    deleteTeacherResult.GetErrorMessage(),
+                    HttpStatusCode.InternalServerError
+                );
+            }
+
+            return Result.Success();
+        }
+    }
+}

--- a/backend/api/src/EduGraph.Core/Features/Teachers/GetAll.cs
+++ b/backend/api/src/EduGraph.Core/Features/Teachers/GetAll.cs
@@ -1,0 +1,59 @@
+using EduGraph.Core.Features.Common.Auth;
+using EduGraph.Core.Features.Common.Dto;
+using EduGraph.Core.Features.Common.Endpoints;
+using EduGraph.Core.Features.Common.Extensions;
+using EduGraph.Core.Features.Common.Parameters;
+using EduGraph.Domain.Enums;
+using EduGraph.Infrastructure.SQLite;
+using EduGraph.Infrastructure.SQLite.Entities;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace EduGraph.Core.Features.Teachers;
+
+internal static class GetAll
+{
+    internal sealed record Response(
+        int Id,
+        string FullName,
+        string Type,
+        DateOnly? LastLoginDate
+    );
+
+    internal sealed class Endpoint : IEndpoint
+    {
+        public void MapEndpoint(IEndpointRouteBuilder app)
+        {
+            app.MapGet("teachers", Handle)
+                .RequireAuthorization(AuthorizationPolicies.Admin)
+                .WithTags("Teachers")
+                .Produces<Pagination<Response>>();
+        }
+
+        private static async Task<Ok<Pagination<Response>>> Handle(
+            [AsParameters] PaginationParams paginationParams,
+            [FromServices] EduGraphContext db,
+            CancellationToken cancellationToken)
+        {
+            IQueryable<User> query = db.Users
+                .AsNoTracking()
+                .Where(user => user.Type == UserType.Teacher)
+                .OrderBy(user => user.Id);
+
+            Pagination<Response> pageDto = await query
+                .ToPagedListAsync(
+                    paginationParams,
+                    user => new Response(
+                        user.Id,
+                        user.FullName,
+                        user.Type.ToString(),
+                        user.LastLoginDate
+                    ),
+                    cancellationToken
+                );
+
+            return TypedResults.Ok(pageDto);
+        }
+    }
+}


### PR DESCRIPTION
Adds admin-only teacher user endpoints:

- POST `teachers` to create a teacher user.
- GET `teachers` to return paginated teacher users via `PaginationParams` and `ToPagedListAsync`.
- DELETE `teachers/{id:int}` to delete a teacher user.

Handlers are used for create and delete to keep Identity and transaction logic outside the endpoint methods.